### PR TITLE
Changing Formspree email contact

### DIFF
--- a/speaking/index.html
+++ b/speaking/index.html
@@ -70,7 +70,7 @@
                     <p class="model-events-text" style="text-align: center;">We welcome feedback, comments, and suggestions. To request a speaking engagement, please click <a href="../speaking/index.html">here</a>.</p>
                     <div class="sub-field-div">
 
-                      <input type="hidden" name="_cc" value="deleg008@umn.edu" />
+                      <input type="hidden" name="_cc" value="mapprejudice@umn.edu" />
 
                       <p class="field-text">Name</p>
                       <input type="text" name="name" class="form-field">
@@ -321,7 +321,7 @@
               <form action="https://formspree.io/kevinesolberg@gmail.com" method="POST" class="form-style">
                 <div class="field-div">
                   <div class="sub-field-div" style="display: inline-block;">
-                    <input type="hidden" name="_cc" value="deleg008@umn.edu"/>
+                    <input type="hidden" name="_cc" value="mapprejudice@umn.edu"/>
                     <p style="text-align: left; padding: 0%;">Get in touch.</p>
 
                     <div class="flex">
@@ -397,7 +397,7 @@
               <form action="https://formspree.io/kevinesolberg@gmail.com" method="POST" class="form-style">
                 <div class="field-div">
                   <div class="sub-field-div" style="display: inline-block;">
-                    <input type="hidden" name="_cc" value="deleg008@umn.edu"/>
+                    <input type="hidden" name="_cc" value="mapprejudice@umn.edu"/>
                     <p style="text-align: left; padding: 0%;">To set up a speaking engagement, please fill out the form below</p>
 
                     <div class="flex">


### PR DESCRIPTION
Changed so that emails go to mapprejudice@umn.edu instead of Kirsten Delegard directly.