### PR TITLE
Adding response timing disclaimer for Contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,10 @@
                 <form action="https://formspree.io/kevinesolberg@gmail.com" method="POST" class="form-style">
                   <div class="field-div">
                     <p class="model-events-text" style="text-align: center;">We welcome feedback, comments, and suggestions. To request a speaking engagement, please click <a href="speaking/index.html">here</a>.</p>
+                    
+                    <!-- Adding disclaimer -->
+                    <p class="model-events-text" style="text-align: center;">Our team is taking time to grieve and re-group after the <a href="https://www.startribune.com/kevin-ehrman-solberg-mapping-prejudice-project-co-founder-dies-at-33/600069468/?refresh=true">death of our colleague and friend, Kevin Ehrman-Solberg</a>. Kevin was one of the co-founders of Mapping Prejudice and served as our digital and geospatial director. We are working on re-organizing our team and our workflows so that we can continue this important work. Please be aware that our responses to your inquiries may be slow.</p>
+                    
                     <div class="sub-field-div">
 
                       <input type="hidden" name="_cc" value="deleg008@umn.edu" />


### PR DESCRIPTION
Now realizing this (clicking contact pop-up) is part of the header...which means we'd have to do it on every page. But given that we're contracting for an entirely new site, I think changing the header on the home page should be enough.