### PR TITLE
Front page highlights changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,21 +320,21 @@
       <div class="content-block-2" style="background-color: #dbd9e200;" id="main">
         <div class="flex">
 
-          <!-- ** 'ABOUT' HIGHLIGHT BOX ** -->
-          <a id="link-box-1" href="about-us/index.html" class="hvr-fade">
+          <!-- ** 'NEWS' HIGHLIGHT BOX ** -->
+          <a id="link-box-1" href="https://hr.myu.umn.edu/jobs/ext/342457" class="hvr-fade">
             <h3 class="flex-title">about</h3>
             <img class="press-imgs" src="images/about-front-page.JPG" alt="Article Link">
-            <p class="flex-para"> <b>Mapping Prejudice</b>
-              <br>We are a team of geographers, historians, digital humanists and community activists seeking to expose structural racism. We have led community members in the work of unearthing thousands of racial covenants that reserved land for the exclusive use of white people. This allowed us to build a map that shows how these racial restrictions were embedded in the physical landscape. We are expanding the geographic focus of our work to incorporate new communities. Please join us in this effort.</p>
+            <p class="flex-para"> <b>Position Announcement</b>
+              <br>Please join our collaborative team and help us shape the future of Mapping Prejudice. We are hiring a new associate director to lead our geospatial, tech and data work: <a href="https://hr.myu.umn.edu/jobs/ext/342457">https://hr.myu.umn.edu/jobs/ext/342457</a></p>
             <div class="flex-btn-div">
-              <p class="flex-btn">Meet Our Team</p>
+              <p class="flex-btn">Learn More</p>
             </div>
           </a>
 
 
-          <!-- ** 'NEWS' HIGHLIGHT BOX ** -->
+          <!-- ** 'MAPS & DATA' HIGHLIGHT BOX ** -->
           <a id="link-box-2" class="hvr-fade" target="blank" href="data-and-map-launch-page/index.html">
-            <h3 class="flex-title">news</h3>
+            <h3 class="flex-title">MAPS & DATA</h3>
               <img class="press-imgs" src="images/front-page_MappingPrejudiceThumbnail_02122020.jpg" alt="Article Link">
             <p class="flex-para"> <b>Hennepin County Data and Maps Available</b><br>
               Data pertaining to the location of racial covenants in Hennepin County between 1910 and 1955 have been deposited in the Data Repository for the University of Minnesota. You can view this data<br>


### PR DESCRIPTION
Changed "News" heading to "Maps & Data" as a permanent feature. Already moved text from "About" to the About Us page, so changed "About" to "News" and added a news item (position posting).